### PR TITLE
Added some basic failure tests, minor refactoring

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,9 @@ attrs==18.2.0
 certifi==2018.10.15
 chardet==3.0.4
 idna==2.7
+mock==2.0.0
 more-itertools==4.3.0
+pbr==5.1.0
 pluggy==0.8.0
 py==1.7.0
 pymongo==3.7.2

--- a/src/api.py
+++ b/src/api.py
@@ -13,6 +13,7 @@ import os
 
 # constants
 from bson import ObjectId
+from bson.errors import InvalidId as BsonInvalidIdError
 from tornado import escape
 
 from src.database import DatabaseResolver
@@ -454,7 +455,12 @@ class HeartBeatHandler(RequestHandlerBase):
 
         worker_id = escape.to_basestring(self.request.arguments['worker_id'][0])
 
-        worker_node = worker_nodes_collection.find_one({'_id': ObjectId(worker_id)})
+        try:
+            worker_node = worker_nodes_collection.find_one({'_id': ObjectId(worker_id)})
+        except BsonInvalidIdError:
+            self.bad_request('\'worker_id\' invalid')
+            return
+
         if worker_node is None:
             self.bad_request("Worker node with id {} does not exist".format(worker_id))
             return

--- a/src/api.py
+++ b/src/api.py
@@ -13,7 +13,6 @@ import os
 
 # constants
 from bson import ObjectId
-from bson.errors import InvalidId as BsonInvalidIdError
 from tornado import escape
 
 from src.database import DatabaseResolver
@@ -21,7 +20,6 @@ from src.settings import LOGS_DIR_NAME, ID_REGEX, TIMESTAMP_FORMAT, PORT, HEARTB
     EMPTY_QUEUE_CODE
 
 # globals
-heartbeat_validator_thread = None
 cluster_token = None
 job_queue = Queue()
 heartbeat = True
@@ -133,7 +131,7 @@ def generate_random_key(length):
 def enqueue_job(job_id, db_resolver):
     jobs_collection = db_resolver.get_jobs_collection()
     cur_job = {}
-    job = jobs_collection.find_one({'_id': ObjectId(job_id)})
+    job = db_resolver.get_grading_job(job_id)
     assert job is not None
     cur_job['stages'] = job['stages']
     cur_job['job_id'] = job_id
@@ -246,6 +244,7 @@ class AddGradingRunHandler(RequestHandlerBase):
         db_handler: DatabaseResolver = self.settings['db_object']
         jobs_collection = db_handler.get_jobs_collection()
         grading_runs_collection = db_handler.get_grading_run_collection()
+
         # arguments are valid so feed into DB and return run id
         grading_run = {'created_at': get_time(), 'student_jobs_left': len(student_jobs)}
         grading_run_id = str(grading_runs_collection.insert_one(grading_run).inserted_id)
@@ -273,7 +272,7 @@ class GradingRunHandler(RequestHandlerBase):
         db_handler: DatabaseResolver = self.settings['db_object']
         grading_runs_collection = db_handler.get_grading_run_collection()
         grading_run_id = id_
-        grading_run = grading_runs_collection.find_one({'_id': ObjectId(grading_run_id)})
+        grading_run = db_handler.get_grading_run(grading_run_id)
         if grading_run is None:
             self.bad_request("Grading Run with id {} does not exist".format(grading_run_id))
             return
@@ -292,9 +291,7 @@ class GradingRunHandler(RequestHandlerBase):
     def get(self, id_):
         db_handler: DatabaseResolver = self.settings['db_object']
         grading_run_id = id_
-        grading_runs_collection = db_handler.get_grading_run_collection()
-        jobs_collection = db_handler.get_jobs_collection()
-        grading_run = grading_runs_collection.find_one({'_id': ObjectId(grading_run_id)})
+        grading_run = db_handler.get_grading_run(grading_run_id)
         if grading_run is None:
             self.bad_request("Grading Run with id {} does not exist".format(grading_run_id))
             return
@@ -302,7 +299,7 @@ class GradingRunHandler(RequestHandlerBase):
         res = {'student_statuses': []}
 
         for student_job_id in grading_run['student_job_ids']:
-            student_job = jobs_collection.find_one({'_id': ObjectId(student_job_id)})
+            student_job = db_handler.get_grading_job(student_job_id)
             stages = []
             for stage in student_job['stages']:
                 stage_temp = {'image': stage['image'], 'env': dict([env.split("=") for env in stage['env']])}
@@ -312,7 +309,7 @@ class GradingRunHandler(RequestHandlerBase):
                 {'job_id': student_job_id, 'status': get_status(student_job), 'stages': stages})
 
         if grading_run['postprocessing_job_id'] is not None:
-            postprocessing_job = jobs_collection.find_one({'_id': ObjectId(grading_run['postprocessing_job_id'])})
+            postprocessing_job = db_handler.get_grading_job(grading_run['postprocessing_job_id'])
             assert postprocessing_job is not None
             res['postprocessing_status'] = {'job_id': grading_run['postprocessing_job_id'],
                                             'status': get_status(postprocessing_job)}
@@ -333,7 +330,7 @@ class GradingJobHandler(RequestHandlerBase):
         jobs_collection = db_handler.get_jobs_collection()
 
         worker_id = escape.to_basestring(self.request.arguments['worker_id'][0])
-        worker_node = worker_nodes_collection.find_one({'_id': ObjectId(worker_id)})
+        worker_node = db_handler.get_worker_node(worker_id)
         if worker_node is None:
             self.bad_request("Worker node with id {} does not exist".format(worker_id))
             return
@@ -366,13 +363,13 @@ class JobUpdateHandler(RequestHandlerBase):
 
         job_id = id_
         worker_id = escape.to_basestring(self.request.arguments['worker_id'][0])
-        worker_node = worker_nodes_collection.find_one({'_id': ObjectId(worker_id)})
+        worker_node = db_handler.get_worker_node(worker_id)
         if worker_node is None:
             self.bad_request("Worker node with id {} does not exist".format(worker_id))
             return
 
         # check if the job exists
-        job = jobs_collection.find_one({'_id': ObjectId(job_id)})
+        job = db_handler.get_grading_job(job_id)
         if job is None:
             self.bad_request("Job with id {} does not exist".format(job_id))
             return
@@ -397,7 +394,7 @@ class JobUpdateHandler(RequestHandlerBase):
         # update grading run: if last job finished then update finished_at. Update student_jobs_left if student job.
         # enqueue post processing if all student jobs finished
         assert "grading_run_id" in job
-        grading_run = grading_runs_collection.find_one({'_id': ObjectId(job["grading_run_id"])})
+        grading_run = db_handler.get_grading_run(job["grading_run_id"])
 
         assert "created_at" in grading_run
         assert "started_at" in grading_run
@@ -454,13 +451,7 @@ class HeartBeatHandler(RequestHandlerBase):
             return
 
         worker_id = escape.to_basestring(self.request.arguments['worker_id'][0])
-
-        try:
-            worker_node = worker_nodes_collection.find_one({'_id': ObjectId(worker_id)})
-        except BsonInvalidIdError:
-            self.bad_request('\'worker_id\' invalid')
-            return
-
+        worker_node = db_handler.get_worker_node(worker_id)
         if worker_node is None:
             self.bad_request("Worker node with id {} does not exist".format(worker_id))
             return
@@ -468,15 +459,25 @@ class HeartBeatHandler(RequestHandlerBase):
         worker_nodes_collection.update_one({'_id': ObjectId(worker_id)}, {"$set": {'last_seen': get_time()}})
         logging.info("Heartbeat from {}".format(worker_id))
 
-def api_initialize():
-    # set up logger
+
+def set_up_logger():
     if not os.path.exists(LOGS_DIR_NAME):
         os.makedirs(LOGS_DIR_NAME)
     logging.basicConfig(filename='{}/{}.log'.format(LOGS_DIR_NAME, get_time()), level=logging.DEBUG)
 
-    # set up cluster token
+
+def initialize_cluster_token():
+    global cluster_token
     cluster_token = generate_random_key(30)
     print("Nodes can join the cluster using token: {}".format(cluster_token))
+
+
+if __name__ == "__main__":
+    # set up logger
+    set_up_logger()
+
+    # set up cluster token
+    initialize_cluster_token()
 
     app = make_app(DatabaseResolver())
     app.listen(PORT)
@@ -485,6 +486,7 @@ def api_initialize():
     heartbeat_validator_thread = Thread(target=heartbeat_validator, args=[app.settings["db_object"]])
     heartbeat_validator_thread.start()
 
+    # start the API
     try:
         tornado.ioloop.IOLoop.current().start()
     except KeyboardInterrupt:
@@ -496,9 +498,3 @@ def api_initialize():
     heartbeat_cv.notify()
     heartbeat_cv.release()
     heartbeat_validator_thread.join()
-
-    return app, cluster_token
-
-if __name__ == "__main__":
-    # Extracted out to seperate method for possible future testing w/ graders
-    api_initialize()

--- a/src/api.py
+++ b/src/api.py
@@ -462,8 +462,7 @@ class HeartBeatHandler(RequestHandlerBase):
         worker_nodes_collection.update_one({'_id': ObjectId(worker_id)}, {"$set": {'last_seen': get_time()}})
         logging.info("Heartbeat from {}".format(worker_id))
 
-
-if __name__ == "__main__":
+def api_initialize():
     # set up logger
     if not os.path.exists(LOGS_DIR_NAME):
         os.makedirs(LOGS_DIR_NAME)
@@ -473,7 +472,6 @@ if __name__ == "__main__":
     cluster_token = generate_random_key(30)
     print("Nodes can join the cluster using token: {}".format(cluster_token))
 
-    # start the API
     app = make_app(DatabaseResolver())
     app.listen(PORT)
 
@@ -492,3 +490,9 @@ if __name__ == "__main__":
     heartbeat_cv.notify()
     heartbeat_cv.release()
     heartbeat_validator_thread.join()
+
+    return app, cluster_token
+
+if __name__ == "__main__":
+    # Extracted out to seperate method for possible future testing w/ graders
+    api_initialize()

--- a/src/database.py
+++ b/src/database.py
@@ -1,4 +1,5 @@
 from pymongo import MongoClient
+from bson import ObjectId
 
 
 class DatabaseResolver(object):
@@ -8,6 +9,9 @@ class DatabaseResolver(object):
         self.db_name = db_name
         self.db = self.client[self.db_name]
 
+    def is_id_valid(self, id_):
+        return ObjectId.is_valid(id_)
+
     def get_workers_node_collection(self):
         # Worker Node:
         #   id (implicit)
@@ -15,6 +19,12 @@ class DatabaseResolver(object):
         #   running_job_ids         None if not executing any job
 
         return self.db.worker_nodes
+
+    def get_worker_node(self, id_):
+        if self.is_id_valid(id_):
+            return self.get_workers_node_collection().find_one({'_id': ObjectId(id_)})
+        else:
+            return None
 
     def get_grading_run_collection(self):
         # Grading Run:
@@ -28,6 +38,12 @@ class DatabaseResolver(object):
 
         return self.db.grading_runs
 
+    def get_grading_run(self, id_):
+        if self.is_id_valid(id_):
+            return self.get_grading_run_collection().find_one({'_id': ObjectId(id_)})
+        else:
+            return None
+
     def get_jobs_collection(self):
         # Job:
         #   id (implicit)
@@ -40,6 +56,12 @@ class DatabaseResolver(object):
         #   stages = [stage1, stage2, ...] with all environment variables expanded
 
         return self.db.jobs
+
+    def get_grading_job(self, id_):
+        if self.is_id_valid(id_):
+            return self.get_jobs_collection().find_one({'_id': ObjectId(id_)})
+        else:
+            return None
 
     def clear_db(self):
         self.client.drop_database(self.db_name)

--- a/tests/integration/test_grading_run.py
+++ b/tests/integration/test_grading_run.py
@@ -3,6 +3,7 @@ from tornado import gen
 import json
 from src.api import make_app
 from src.database import DatabaseResolver
+from src.settings import EMPTY_QUEUE_CODE
 import urllib
 import tornado
 
@@ -170,3 +171,58 @@ class TestGradingRun(HTTPTestBase):
             yield fetch(self.get_url('/api/v1/grading_run'), method='POST', headers=None, body='')
 
         self.assertTrue(400 <= context.exception.code <= 499)
+
+    @gen_test
+    def test_invalid_worker_register(self):
+        wr_invalid_token = '/api/v1/worker_register?token=ofsomething'
+        with self.assertRaises(tornado.httpclient.HTTPError) as context:
+            yield fetch(self.get_url(wr_invalid_token), method='GET',
+                    headers=None)
+        self.assertTrue(400 <= context.exception.code <= 499)
+
+    @gen_test
+    def test_missing_worker_register(self):
+        wr_missing_token = '/api/v1/worker_register'
+        with self.assertRaises(tornado.httpclient.HTTPError) as context:
+            yield fetch(self.get_url(wr_missing_token), method='GET',
+                    headers=None)
+        self.assertTrue(400 <= context.exception.code <= 499)
+
+    @gen_test
+    def test_invalid_worker_get_gj(self):
+        with self.assertRaises(tornado.httpclient.HTTPError) as context:
+            yield fetch(self.get_url('/api/v1/grading_run?worker_id=-1'), method='GET',
+                    headers=None)
+        self.assertTrue(400 <= context.exception.code <= 499)
+
+    @gen_test
+    def test_missing_worker_get_gj(self):
+        with self.assertRaises(tornado.httpclient.HTTPError) as context:
+            yield fetch(self.get_url('/api/v1/grading_run'), method='GET',
+                    headers=None)
+        self.assertTrue(400 <= context.exception.code <= 499)
+
+
+    @gen_test
+    def test_invalid_worker_job_post_gj(self):
+        with self.assertRaises(tornado.httpclient.HTTPError) as context:
+            job_id = -1
+            grading_job_url = '/api/v1/grading_job/{0}'.format(job_id)
+            yield fetch(self.get_url(grading_job_url), method='POST',
+                    headers=None, body='')
+            self.assertTrue(400 <= context.exception.code <= 499)
+
+    @gen_test
+    def test_invalid_worker_heartbeat(self):
+        with self.assertRaises(tornado.httpclient.HTTPError) as context:
+            yield fetch(self.get_url('/api/v1/heartbeat?worker_id=-1'), method='GET',
+                    headers=None)
+        self.assertTrue(400 <= context.exception.code <= 499)
+
+    @gen_test
+    def test_missing_worker_heartbeat(self):
+        with self.assertRaises(tornado.httpclient.HTTPError) as context:
+            yield fetch(self.get_url('/api/v1/heartbeat'), method='GET',
+                    headers=None)
+        self.assertTrue(400 <= context.exception.code <= 499)
+

--- a/tests/integration/test_grading_run.py
+++ b/tests/integration/test_grading_run.py
@@ -173,6 +173,20 @@ class TestGradingRun(HTTPTestBase):
         self.assertTrue(400 <= context.exception.code <= 499)
 
     @gen_test
+    def test_invalid_run_get_gr(self):
+        with self.assertRaises(tornado.httpclient.HTTPError) as context:
+            yield fetch(self.get_url('/api/v1/grading_run/-1'), method='GET',
+                    headers=None)
+        self.assertTrue(400 <= context.exception.code <= 499)
+
+    @gen_test
+    def test_missing_run_get_gr(self):
+        with self.assertRaises(tornado.httpclient.HTTPError) as context:
+            yield fetch(self.get_url('/api/v1/grading_run'), method='GET',
+                    headers=None)
+        self.assertTrue(400 <= context.exception.code <= 499)
+
+    @gen_test
     def test_invalid_worker_register(self):
         wr_invalid_token = '/api/v1/worker_register?token=ofsomething'
         with self.assertRaises(tornado.httpclient.HTTPError) as context:
@@ -189,22 +203,7 @@ class TestGradingRun(HTTPTestBase):
         self.assertTrue(400 <= context.exception.code <= 499)
 
     @gen_test
-    def test_invalid_worker_get_gj(self):
-        with self.assertRaises(tornado.httpclient.HTTPError) as context:
-            yield fetch(self.get_url('/api/v1/grading_run?worker_id=-1'), method='GET',
-                    headers=None)
-        self.assertTrue(400 <= context.exception.code <= 499)
-
-    @gen_test
-    def test_missing_worker_get_gj(self):
-        with self.assertRaises(tornado.httpclient.HTTPError) as context:
-            yield fetch(self.get_url('/api/v1/grading_run'), method='GET',
-                    headers=None)
-        self.assertTrue(400 <= context.exception.code <= 499)
-
-
-    @gen_test
-    def test_invalid_worker_job_post_gj(self):
+    def test_invalid_worker_post_gj(self):
         with self.assertRaises(tornado.httpclient.HTTPError) as context:
             job_id = -1
             grading_job_url = '/api/v1/grading_job/{0}'.format(job_id)
@@ -213,16 +212,40 @@ class TestGradingRun(HTTPTestBase):
             self.assertTrue(400 <= context.exception.code <= 499)
 
     @gen_test
+    def test_missing_worker_post_gj(self):
+        with self.assertRaises(tornado.httpclient.HTTPError) as context:
+            grading_job_url = '/api/v1/grading_job/'
+            yield fetch(self.get_url(grading_job_url), method='POST',
+                    headers=None, body='')
+            self.assertTrue(400 <= context.exception.code <= 499)
+
+    @gen_test
+    def test_missing_worker_get_gj(self):
+        with self.assertRaises(tornado.httpclient.HTTPError) as context:
+            grading_job_url = '/api/v1/grading_job/'
+            yield fetch(self.get_url(grading_job_url), method='GET',
+                    headers=None)
+            self.assertTrue(400 <= context.exception.code <= 499)
+
+    @gen_test
+    def test_invalid_worker_get_gj(self):
+        with self.assertRaises(tornado.httpclient.HTTPError) as context:
+            grading_job_url = '/api/v1/grading_job?worker_id=-1'
+            yield fetch(self.get_url(grading_job_url), method='GET',
+                    headers=None)
+            self.assertTrue(400 <= context.exception.code <= 499)
+
+    @gen_test
     def test_invalid_worker_heartbeat(self):
         with self.assertRaises(tornado.httpclient.HTTPError) as context:
-            yield fetch(self.get_url('/api/v1/heartbeat?worker_id=-1'), method='GET',
-                    headers=None)
+            yield fetch(self.get_url('/api/v1/heartbeat?worker_id=-1'), method='POST',
+                    headers=None, body='')
         self.assertTrue(400 <= context.exception.code <= 499)
 
     @gen_test
     def test_missing_worker_heartbeat(self):
         with self.assertRaises(tornado.httpclient.HTTPError) as context:
-            yield fetch(self.get_url('/api/v1/heartbeat'), method='GET',
-                    headers=None)
+            yield fetch(self.get_url('/api/v1/heartbeat'), method='POST',
+                    headers=None, body='')
         self.assertTrue(400 <= context.exception.code <= 499)
 


### PR DESCRIPTION
Added some basic tests for grader endpoints, only tests if arguments missing/invalid
If we want to test the grader endpoints from the same framework it might be easier if we set up a default cluster_token value, not sure if this is a potential security issue