### PR TITLE
Grading Run and Job Id in env var

### DIFF
--- a/src/constants/keys.py
+++ b/src/constants/keys.py
@@ -18,7 +18,8 @@ LOGS = "logs"
 PRE_PROCESSING_STATE = "pre_processing_job_state"
 POST_PROCESSING_STATE = "post_processing_job_state"
 STUDENTS_STATE = "student_jobs_state"
-
+RUN_ENV = "GRADING_RUN_ENV"
+JOB_ENV = "GRADING_JOB_ENV"
 
 # these define url parameters
 HOSTNAME_PARAM = "hostname"

--- a/src/handlers/schedulers.py
+++ b/src/handlers/schedulers.py
@@ -22,7 +22,6 @@ def progress_grading_run(db_resolver, job_queue, grading_run_id):
     :type job_queue: Queue
     :param grading_run_id: used to identify the grading run for which we need to schedule jobs
     :type grading_run_id: str
-    :return:
     """
     grading_run_collection = db_resolver.get_grading_run_collection()
     grading_job_collection = db_resolver.get_grading_job_collection()
@@ -31,6 +30,9 @@ def progress_grading_run(db_resolver, job_queue, grading_run_id):
     assignment = db_resolver.get_assignment_collection().find_one({key.ID: grading_run.get(key.ASSIGNMENT_ID)})
     old_state = grading_run.get(key.STATE)
 
+    global_env_vars = assignment.get(key.ENV, {})
+    global_env_vars[key.RUN_ENV] = grading_run_id
+
     # schedule appropriate jobs
     if old_state == GradingRunState.READY.value and key.PRE_PROCESSING_PIPELINE in assignment:
         grading_run_collection.update_one({key.ID: ObjectId(grading_run_id)},
@@ -38,11 +40,16 @@ def progress_grading_run(db_resolver, job_queue, grading_run_id):
 
         pre_processing_job = {key.TYPE: GradingJobType.PRE_PROCESSING.value,
                               key.GRADING_RUN_ID: grading_run_id,
-                              key.QUEUED: get_time(),
-                              key.STAGES: build_pipeline(assignment.get(key.PRE_PROCESSING_PIPELINE),
-                                                         assignment.get(key.ENV, {}),
-                                                         grading_run.get(key.PRE_PROCESSING_ENV, {}))}
-        job_queue.put(str(grading_job_collection.insert_one(pre_processing_job).inserted_id))
+                              key.QUEUED: get_time()}
+        grading_job_id = str(grading_job_collection.insert_one(pre_processing_job).inserted_id)
+        global_env_vars[key.JOB_ENV] = grading_job_id
+        grading_job_collection.update_one({key.ID: ObjectId(grading_job_id)},
+                                          {'$set': {
+                                              key.STAGES: build_pipeline(assignment.get(key.PRE_PROCESSING_PIPELINE),
+                                                                         global_env_vars,
+                                                                         grading_run.get(key.PRE_PROCESSING_ENV, {}))
+                                          }})
+        job_queue.put(grading_job_id)
 
     elif (old_state == GradingRunState.READY.value and key.PRE_PROCESSING_PIPELINE not in assignment) or (
             old_state == GradingRunState.PRE_PROCESSING_STAGE.value):
@@ -52,11 +59,15 @@ def progress_grading_run(db_resolver, job_queue, grading_run_id):
         for cur_student_env in grading_run.get(key.STUDENTS_ENV):
             cur_student_job = {key.TYPE: GradingJobType.STUDENT.value,
                                key.GRADING_RUN_ID: grading_run_id,
-                               key.QUEUED: get_time(),
-                               key.STAGES: build_pipeline(assignment.get(key.STUDENT_PIPELINE),
-                                                          assignment.get(key.ENV, {}),
-                                                          cur_student_env)}
-            job_queue.put(str(grading_job_collection.insert_one(cur_student_job).inserted_id))
+                               key.QUEUED: get_time()}
+            grading_job_id = str(grading_job_collection.insert_one(cur_student_job).inserted_id)
+            global_env_vars[key.JOB_ENV] = grading_job_id
+            grading_job_collection.update_one({key.ID: ObjectId(grading_job_id)},
+                                              {'$set': {
+                                                  key.STAGES: build_pipeline(assignment.get(key.STUDENT_PIPELINE),
+                                                                             global_env_vars, cur_student_env)
+                                              }})
+            job_queue.put(grading_job_id)
 
     elif old_state == GradingRunState.STUDENTS_STAGE.value and key.POST_PROCESSING_PIPELINE in assignment:
         grading_run_collection.update_one({key.ID: ObjectId(grading_run_id)},
@@ -64,11 +75,16 @@ def progress_grading_run(db_resolver, job_queue, grading_run_id):
 
         post_processing_job = {key.TYPE: GradingJobType.POST_PROCESSING.value,
                                key.GRADING_RUN_ID: grading_run_id,
-                               key.QUEUED: get_time(),
-                               key.STAGES: build_pipeline(assignment.get(key.POST_PROCESSING_PIPELINE),
-                                                          assignment.get(key.ENV, {}),
-                                                          grading_run.get(key.POST_PROCESSING_ENV, {}))}
-        job_queue.put(str(grading_job_collection.insert_one(post_processing_job).inserted_id))
+                               key.QUEUED: get_time()}
+        grading_job_id = str(grading_job_collection.insert_one(post_processing_job).inserted_id)
+        global_env_vars[key.JOB_ENV] = grading_job_id
+        grading_job_collection.update_one({key.ID: ObjectId(grading_job_id)},
+                                          {'$set': {
+                                              key.STAGES: build_pipeline(assignment.get(key.POST_PROCESSING_PIPELINE),
+                                                                         global_env_vars,
+                                                                         grading_run.get(key.POST_PROCESSING_ENV, {}))
+                                          }})
+        job_queue.put(grading_job_id)
 
     elif (old_state == GradingRunState.STUDENTS_STAGE.value and key.POST_PROCESSING_PIPELINE not in assignment) or (
             old_state == GradingRunState.POST_PROCESSING_STAGE.value):

--- a/tests/base.py
+++ b/tests/base.py
@@ -51,8 +51,10 @@ class BaseTest(unittest.TestCase):
         self.assertEqual(set(actual_stage.keys()), set(expected_stage.keys()))
 
         for stage_key in expected_stage:
-            if stage_key == key.ENV or stage_key == key.ENTRY_POINT:
-                self.assertEqual(sorted(actual_stage.get(stage_key)), sorted(expected_stage.get(stage_key)))
+            if stage_key == key.ENV:
+                self.assertTrue(set(expected_stage[key.ENV].keys()).issubset(set(actual_stage[key.ENV].keys())))
+                for env_key in expected_stage.get(stage_key):
+                    self.assertEqual(actual_stage[key.ENV][env_key], expected_stage[key.ENV][env_key])
             else:
                 self.assertEqual(actual_stage.get(stage_key), expected_stage.get(stage_key))
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -199,8 +199,10 @@ class EndpointTestIntegration(BaseEndpointTest):
         for stage in pre_processing_pipeline:
             if key.ENV in stage:
                 stage[key.ENV].update(dummy_configs.complete_config.get(key.ENV, {}))
-                stage[key.ENV].update({"type": "pre"})
+                stage[key.ENV].update({"type": "pre", key.RUN_ENV: grading_run_id})
         self.assert_equal_grading_pipeline(pre_processing_job.get(key.STAGES), pre_processing_pipeline)
+        for stage in pre_processing_job.get(key.STAGES):
+            self.assertIn(key.JOB_ENV, stage[key.ENV])
 
         self.post_job_result(worker_id, self.grader_header, pre_processing_job.get(key.GRADING_JOB_ID))
         self.check_grading_run_status(self.course1, "assignment1", grading_run_id, self.client_header1,
@@ -215,8 +217,10 @@ class EndpointTestIntegration(BaseEndpointTest):
             for stage in student_pipeline:
                 if key.ENV in stage:
                     stage[key.ENV].update(dummy_configs.complete_config.get(key.ENV, {}))
-                    stage[key.ENV].update({"netid": "test net id {}".format(ind)})
+                    stage[key.ENV].update({"netid": "test net id {}".format(ind), key.RUN_ENV: grading_run_id})
             self.assert_equal_grading_pipeline(student_job.get(key.STAGES), student_pipeline)
+            for stage in student_job.get(key.STAGES):
+                self.assertIn(key.JOB_ENV, stage[key.ENV])
 
             self.check_grading_run_status(self.course1, "assignment1", grading_run_id, self.client_header1,
                                           OK_REQUEST_CODE, GradingRunState.STUDENTS_STAGE.value)
@@ -238,8 +242,10 @@ class EndpointTestIntegration(BaseEndpointTest):
         for stage in post_processing_pipeline:
             if key.ENV in stage:
                 stage[key.ENV].update(dummy_configs.complete_config.get(key.ENV, {}))
-                stage[key.ENV].update({"type": "post"})
+                stage[key.ENV].update({"type": "post", key.RUN_ENV: grading_run_id})
         self.assert_equal_grading_pipeline(post_processing_job.get(key.STAGES), post_processing_pipeline)
+        for stage in post_processing_job.get(key.STAGES):
+            self.assertIn(key.JOB_ENV, stage[key.ENV])
 
         self.check_grading_run_status(self.course1, "assignment1", grading_run_id, self.client_header1,
                                       OK_REQUEST_CODE, GradingRunState.POST_PROCESSING_STAGE.value)


### PR DESCRIPTION
Added grading run id and grading job id as global environment variables to all stages in all jobs.
This is so that courses have the flexibility of building containers which use these to identify runs, etc.