### PR TITLE
Change worker register endpoints

### DIFF
--- a/api.py
+++ b/api.py
@@ -64,7 +64,7 @@ def initialize_app():
     }
 
     hex_regex = r"(?P<{}>[a-f0-9]+)"
-    id_regex = r"(?P<{}>[-\w]+)"
+    id_regex = r"(?P<{}>[-\w0-9]+)"
     string_regex = r"(?P<{}>[^()]+)"
 
     return tornado.web.Application(
@@ -103,15 +103,15 @@ def initialize_app():
             # ----------------------------------
             # ------- Worker Endpoints ---------
             (
-                r"/api/v1/worker/{}".format(string_regex.format("hostname")),
+                r"/api/v1/worker/{}".format(id_regex.format("worker_id")),
                 worker_handlers.WorkerRegisterHandler,
             ),
             (
-                r"/api/v1/grading_job/{}".format(hex_regex.format("worker_id")),
+                r"/api/v1/grading_job/{}".format(id_regex.format("worker_id")),
                 worker_handlers.GradingJobHandler,
             ),
             (
-                r"/api/v1/heartbeat/{}".format(hex_regex.format("worker_id")),
+                r"/api/v1/heartbeat/{}".format(id_regex.format("worker_id")),
                 worker_handlers.HeartBeatHandler,
             ),
             # ----------------------------------

--- a/api.py
+++ b/api.py
@@ -63,7 +63,6 @@ def initialize_app():
         "QUEUE": Queue(),
     }
 
-    hex_regex = r"(?P<{}>[a-f0-9]+)"
     id_regex = r"(?P<{}>[-\w0-9]+)"
     string_regex = r"(?P<{}>[^()]+)"
 

--- a/broadway_api/callbacks/worker.py
+++ b/broadway_api/callbacks/worker.py
@@ -39,11 +39,12 @@ def _handle_lost_worker_node(settings, worker):
             )
         )
         return
-    logger.critical(
-        "worker {} went offline unexpectedly on {} while executing '{}'".format(
-            worker.id, worker.hostname, lost_run_id
+    else:
+        logger.critical(
+            "worker {} went offline unexpectedly on {} while executing '{}'".format(
+                worker.id, worker.hostname, lost_run_id
+            )
         )
-    )
 
     jobs_dao = GradingJobDao(settings)
     job = jobs_dao.find_by_id(lost_run_id)

--- a/broadway_api/callbacks/worker.py
+++ b/broadway_api/callbacks/worker.py
@@ -35,13 +35,13 @@ def _handle_lost_worker_node(settings, worker):
     if not lost_run_id:
         logger.critical(
             "worker '{}' ({}) went offline unexpectedly".format(
-                worker.hostname, worker.id
+                worker.hostname, worker.worker_id
             )
         )
         return
     logger.critical(
         "worker '{}' ({}) went offline unexpectedly while executing '{}'".format(
-            worker.hostname, worker.id, lost_run_id
+            worker.hostname, worker.worker_id, lost_run_id
         )
     )
 

--- a/broadway_api/callbacks/worker.py
+++ b/broadway_api/callbacks/worker.py
@@ -34,14 +34,14 @@ def _handle_lost_worker_node(settings, worker):
 
     if not lost_run_id:
         logger.critical(
-            "worker '{}' ({}) went offline unexpectedly".format(
-                worker.hostname, worker.worker_id
+            "worker {} went offline unexpectedly on {}".format(
+                worker.id, worker.hostname
             )
         )
         return
     logger.critical(
-        "worker '{}' ({}) went offline unexpectedly while executing '{}'".format(
-            worker.hostname, worker.worker_id, lost_run_id
+        "worker {} went offline unexpectedly on {} while executing '{}'".format(
+            worker.id, worker.hostname, lost_run_id
         )
     )
 

--- a/broadway_api/daos/worker_node.py
+++ b/broadway_api/daos/worker_node.py
@@ -23,13 +23,6 @@ class WorkerNodeDao(BaseDao):
     def find_all(self):
         return list(map(self._from_store, self._collection.find()))
 
-    def find_by_id(self, id_):
-        if not ObjectId.is_valid(id_):
-            return None
-        return self._from_store(
-            self._collection.find_one({WorkerNodeDao.ID: ObjectId(id_)})
-        )
-
     def find_by_worker_id(self, worker_id):
         return self._from_store(
             self._collection.find_one({WorkerNodeDao.WORKER_ID: worker_id})

--- a/broadway_api/daos/worker_node.py
+++ b/broadway_api/daos/worker_node.py
@@ -1,5 +1,3 @@
-from bson import ObjectId
-
 from broadway_api.daos.base import BaseDao
 from broadway_api.models import WorkerNode
 

--- a/broadway_api/daos/worker_node.py
+++ b/broadway_api/daos/worker_node.py
@@ -30,8 +30,8 @@ class WorkerNodeDao(BaseDao):
     def find_all(self):
         return list(map(self._from_store, self._collection.find()))
 
-    def find_by_id(self, id):
-        return self._from_store(self._collection.find_one({WorkerNodeDao.ID: id}))
+    def find_by_id(self, id_):
+        return self._from_store(self._collection.find_one({WorkerNodeDao.ID: id_}))
 
     def find_by_hostname(self, hostname):
         return self._from_store(

--- a/broadway_api/daos/worker_node.py
+++ b/broadway_api/daos/worker_node.py
@@ -33,9 +33,7 @@ class WorkerNodeDao(BaseDao):
         return list(map(self._from_store, self._collection.find()))
 
     def find_by_id(self, id):
-        return self._from_store(
-            self._collection.find_one({WorkerNodeDao.ID: id})
-        )
+        return self._from_store(self._collection.find_one({WorkerNodeDao.ID: id}))
 
     def find_by_hostname(self, hostname):
         return self._from_store(

--- a/broadway_api/decorators/auth.py
+++ b/broadway_api/decorators/auth.py
@@ -19,9 +19,17 @@ def authenticate_worker(func):
         worker_id = kwargs.get("worker_id")
 
         dao = WorkerNodeDao(handler.settings)
-        if dao.find_by_id(worker_id) is None:
+
+        worker = dao.find_by_worker_id(worker_id)
+
+        if worker is None:
             handler.abort({"message": "worker not found"}, status=401)
             return
+
+        if not worker.is_alive:
+            handler.abort({"message": "node is not alive"}, status=401)
+            return
+
         return func(*args, **kwargs)
 
     return wrapper

--- a/broadway_api/decorators/auth.py
+++ b/broadway_api/decorators/auth.py
@@ -20,7 +20,7 @@ def authenticate_worker(func):
 
         dao = WorkerNodeDao(handler.settings)
 
-        worker = dao.find_by_worker_id(worker_id)
+        worker = dao.find_by_id(worker_id)
 
         if worker is None:
             handler.abort({"message": "worker not found"}, status=401)

--- a/broadway_api/decorators/auth.py
+++ b/broadway_api/decorators/auth.py
@@ -26,10 +26,6 @@ def authenticate_worker(func):
             handler.abort({"message": "worker not found"}, status=401)
             return
 
-        if not worker.is_alive:
-            handler.abort({"message": "node is not alive"}, status=401)
-            return
-
         return func(*args, **kwargs)
 
     return wrapper

--- a/broadway_api/handlers/worker.py
+++ b/broadway_api/handlers/worker.py
@@ -17,32 +17,43 @@ logger = logging.getLogger("worker")
 class WorkerRegisterHandler(BaseAPIHandler):
     @authenticate_cluster_token
     @schema.validate(
+        on_empty_404=True,
+        input_schema={
+            "type": "object",
+            "properties": {"hostname": {"type": "string"}},
+            "required": ["hostname"],
+            "additionalProperties": False,
+        },
         output_schema={
             "type": "object",
-            "properties": {
-                "worker_id": {"type": "string"},
-                "heartbeat": {"type": "number"},
-            },
-            "required": ["worker_id"],
+            "properties": {"heartbeat": {"type": "number"}},
+            "required": ["heartbeat"],
             "additionalProperties": False,
-        }
+        },
     )
-    def get(self, *args, **kwargs):
-        worker_node_dao = daos.WorkerNodeDao(self.settings)
-        worker_node = models.WorkerNode(
-            hostname=kwargs.get("hostname") if len(args) == 0 else args[0],
-            last_seen=get_time(),
-            is_alive=True,
-        )
-        worker_id = str(worker_node_dao.insert(worker_node).inserted_id)
+    def post(self, *args, **kwargs):
+        worker_id = kwargs.get("worker_id")
+        hostname = self.body.get("hostname")
 
-        logger.info(
-            "worker '{}' joined as id '{}'".format(worker_node.hostname, worker_id)
+        worker_node_dao = daos.WorkerNodeDao(self.settings)
+
+        dup = worker_node_dao.find_by_worker_id(worker_id)
+
+        if dup is not None and dup.is_alive:
+            msg = "worker id '{}' already exists".format(worker_id)
+            logger.critical(msg)
+            self.abort({"message": msg}, status=400)
+            return
+
+        worker_node = models.WorkerNode(
+            worker_id=worker_id, hostname=hostname, last_seen=get_time(), is_alive=True
         )
-        return {
-            "worker_id": worker_id,
-            "heartbeat": self.get_config()["HEARTBEAT_INTERVAL"],
-        }
+
+        worker_node_dao.update(worker_node)
+
+        logger.info("worker '{}' joined as id '{}'".format(hostname, worker_id))
+
+        return {"heartbeat": self.get_config()["HEARTBEAT_INTERVAL"]}
 
 
 class GradingJobHandler(BaseAPIHandler):
@@ -64,9 +75,9 @@ class GradingJobHandler(BaseAPIHandler):
         """
         Allows workers to request their next grading job
         """
-        worker_id = kwargs.get("worker_id") if len(args) == 0 else args[0]
+        worker_id = kwargs.get("worker_id")
         worker_node_dao = daos.WorkerNodeDao(self.settings)
-        worker_node = worker_node_dao.find_by_id(worker_id)
+        worker_node = worker_node_dao.find_by_worker_id(worker_id)
         if not worker_node:
             logger.critical(
                 "unknown node with ID '{}' successfully requested job".format(worker_id)
@@ -120,7 +131,7 @@ class GradingJobHandler(BaseAPIHandler):
         """
         Allows workers to update grading job status on completion
         """
-        worker_id = kwargs.get("worker_id") if len(args) == 0 else args[0]
+        worker_id = kwargs.get("worker_id")
         job_id = self.body.get("grading_job_id")
 
         grading_job_dao = daos.GradingJobDao(self.settings)
@@ -140,7 +151,7 @@ class GradingJobHandler(BaseAPIHandler):
             return
 
         worker_node_dao = daos.WorkerNodeDao(self.settings)
-        worker_node = worker_node_dao.find_by_id(worker_id)
+        worker_node = worker_node_dao.find_by_worker_id(worker_id)
         if not worker_node:
             logger.critical(
                 "unknown node with ID '{}' successfully updated job".format(worker_id)
@@ -173,10 +184,10 @@ class HeartBeatHandler(BaseAPIHandler):
     @authenticate_cluster_token
     @authenticate_worker
     def post(self, *args, **kwargs):
-        worker_id = kwargs.get("worker_id") if len(args) == 0 else args[0]
+        worker_id = kwargs.get("worker_id")
 
         worker_node_dao = daos.WorkerNodeDao(self.settings)
-        worker_node = worker_node_dao.find_by_id(worker_id)
+        worker_node = worker_node_dao.find_by_worker_id(worker_id)
         if not worker_node:
             logger.critical(
                 "unknown node with ID '{}' successfully sent heartbeat".format(

--- a/broadway_api/models/worker_node.py
+++ b/broadway_api/models/worker_node.py
@@ -5,16 +5,14 @@ from datetime import datetime
 class WorkerNode:
     def __init__(
         self,
-        worker_id: str,
+        id_: str,
         hostname: str,
-        id_: Optional[str] = None,
         running_job_id: Optional[str] = None,
         last_seen: Optional[datetime] = None,
         jobs_processed: int = 0,
         is_alive: bool = True,
     ):
         self.id = id_
-        self.worker_id = worker_id
         self.running_job_id = running_job_id
         self.last_seen = last_seen
         self.hostname = hostname

--- a/broadway_api/models/worker_node.py
+++ b/broadway_api/models/worker_node.py
@@ -5,6 +5,7 @@ from datetime import datetime
 class WorkerNode:
     def __init__(
         self,
+        worker_id: str,
         hostname: str,
         id_: Optional[str] = None,
         running_job_id: Optional[str] = None,
@@ -13,6 +14,7 @@ class WorkerNode:
         is_alive: bool = True,
     ):
         self.id = id_
+        self.worker_id = worker_id
         self.running_job_id = running_job_id
         self.last_seen = last_seen
         self.hostname = hostname

--- a/tests/_fixtures/config.py
+++ b/tests/_fixtures/config.py
@@ -11,4 +11,4 @@ DB_PRIMARY = "__test"
 DB_LOGS = "__test_logs"
 DB_PATH = "/data/db"
 
-HEARTBEAT_INTERVAL = 10
+HEARTBEAT_INTERVAL = 2

--- a/tests/base.py
+++ b/tests/base.py
@@ -5,8 +5,10 @@ import unittest
 import sys
 
 from tornado.testing import AsyncHTTPTestCase
+import tornado.ioloop
 
 import broadway_api.definitions as definitions
+import broadway_api.callbacks as callbacks
 import tests._fixtures.config as test_config
 import tests._utils.database as database_utils
 
@@ -38,6 +40,12 @@ class AsyncHTTPMixin(AsyncHTTPTestCase):
                 MOCK_COURSE2: [MOCK_CLIENT_TOKEN1, MOCK_CLIENT_TOKEN2],
             },
         )
+
+        tornado.ioloop.PeriodicCallback(
+            lambda: callbacks.worker_heartbeat_callback(self.app.settings),
+            test_config.HEARTBEAT_INTERVAL * 1000,
+        ).start()
+
         return self.app
 
     def get_token(self):

--- a/tests/base.py
+++ b/tests/base.py
@@ -160,8 +160,10 @@ class ClientMixin(AsyncHTTPMixin):
 
 
 class GraderMixin(AsyncHTTPMixin):
-    def register_worker(self, header, expected_code=200, hostname="mock_hostname"):
-        worker_id = str(uuid.uuid4())
+    def register_worker(
+        self, header, expected_code=200, worker_id=None, hostname="mock_hostname"
+    ):
+        worker_id = worker_id or str(uuid.uuid4())
 
         response = self.fetch(
             self.get_url("/api/v1/worker/{}".format(worker_id)),

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,5 +1,6 @@
 import json
 import jsonschema
+import uuid
 import unittest
 import sys
 
@@ -160,17 +161,19 @@ class ClientMixin(AsyncHTTPMixin):
 
 class GraderMixin(AsyncHTTPMixin):
     def register_worker(self, header, expected_code=200, hostname="mock_hostname"):
+        worker_id = str(uuid.uuid4())
+
         response = self.fetch(
-            self.get_url("/api/v1/worker/{}".format(hostname)),
-            method="GET",
+            self.get_url("/api/v1/worker/{}".format(worker_id)),
+            method="POST",
             headers=header,
+            body=json.dumps({"hostname": hostname}),
         )
+
         self.assertEqual(response.code, expected_code)
 
         if expected_code == 200:
-            response_body = json.loads(response.body.decode("utf-8"))
-            self.assertIn("worker_id", response_body["data"])
-            return response_body["data"].get("worker_id")
+            return worker_id
 
     def poll_job(self, worker_id, header):
         response = self.fetch(

--- a/tests/integration/test_worker.py
+++ b/tests/integration/test_worker.py
@@ -1,6 +1,8 @@
 import logging
+import time
 
 from tests.base import BaseTest
+from tests._fixtures.config import HEARTBEAT_INTERVAL
 
 logging.disable(logging.WARNING)
 
@@ -9,10 +11,15 @@ class RegisterGraderEndpointsTest(BaseTest):
     def test_register(self):
         self.assertIsNotNone(self.register_worker(self.get_header()))
 
-    def test_duplicate_token(self):
+    def test_duplicate_id(self):
         worker_id = "duplicate"
         self.register_worker(self.get_header(), worker_id=worker_id, expected_code=200)
         self.register_worker(self.get_header(), worker_id=worker_id, expected_code=400)
+
+    def test_reregister_id(self):
+        worker_id = self.register_worker(self.get_header(), expected_code=200)
+        time.sleep(HEARTBEAT_INTERVAL * 2)
+        self.register_worker(self.get_header(), worker_id=worker_id, expected_code=200)
 
     def test_unauthorized(self):
         self.register_worker(None, 401)

--- a/tests/integration/test_worker.py
+++ b/tests/integration/test_worker.py
@@ -9,6 +9,11 @@ class RegisterGraderEndpointsTest(BaseTest):
     def test_register(self):
         self.assertIsNotNone(self.register_worker(self.get_header()))
 
+    def test_duplicate_token(self):
+        worker_id = "duplicate"
+        self.register_worker(self.get_header(), worker_id=worker_id, expected_code=200)
+        self.register_worker(self.get_header(), worker_id=worker_id, expected_code=400)
+
     def test_unauthorized(self):
         self.register_worker(None, 401)
 

--- a/tests/integration/test_worker.py
+++ b/tests/integration/test_worker.py
@@ -18,7 +18,7 @@ class RegisterGraderEndpointsTest(BaseTest):
 
     def test_reregister_id(self):
         worker_id = self.register_worker(self.get_header(), expected_code=200)
-        time.sleep(HEARTBEAT_INTERVAL * 2)
+        time.sleep(HEARTBEAT_INTERVAL * 2 + 1)
         self.register_worker(self.get_header(), worker_id=worker_id, expected_code=200)
 
     def test_unauthorized(self):

--- a/tests/unit/test_daos.py
+++ b/tests/unit/test_daos.py
@@ -224,7 +224,8 @@ class WorkerNodeDaoTest(BaseTest):
         self.dao = daos.WorkerNodeDao(self.app.settings)
 
     def _insert_obj(self):
-        return self.dao.update(WorkerNodeDaoTest.DEFAULT_OBJECT)
+        self.dao.update(WorkerNodeDaoTest.DEFAULT_OBJECT)
+        return WorkerNodeDaoTest.DEFAULT_OBJECT.worker_id
 
     def test_find_by_hostname(self):
         self._insert_obj()
@@ -232,16 +233,16 @@ class WorkerNodeDaoTest(BaseTest):
         self.assertIsNotNone(obj)
 
     def test_find_by_liveness(self):
-        result = self._insert_obj()
+        worker_id = self._insert_obj()
         obj_list = self.dao.find_by_liveness(alive=True)
         no_obj_list = self.dao.find_by_liveness(alive=False)
         self.assertEqual(len(obj_list), 1)
         self.assertEqual(len(no_obj_list), 0)
-        self.assertEqual(obj_list[0].id, str(result.inserted_id))
+        self.assertEqual(obj_list[0].worker_id, worker_id)
 
     def test_update(self):
-        insert_result = self._insert_obj()
-        obj = self.dao.find_by_id(insert_result.inserted_id)
+        worker_id = self._insert_obj()
+        obj = self.dao.find_by_worker_id(worker_id)
         obj.is_alive = False
         update_result = self.dao.update(obj)
 

--- a/tests/unit/test_daos.py
+++ b/tests/unit/test_daos.py
@@ -217,15 +217,15 @@ class GradingRunDaoTest(BaseTest):
 
 class WorkerNodeDaoTest(BaseTest):
 
-    DEFAULT_OBJECT = models.WorkerNode(worker_id="holygoply", hostname="example.com")
+    DEFAULT_OBJECT = models.WorkerNode(id_="holygoply", hostname="example.com")
 
     def setUp(self):
         super().setUp()
         self.dao = daos.WorkerNodeDao(self.app.settings)
 
     def _insert_obj(self):
-        self.dao.update(WorkerNodeDaoTest.DEFAULT_OBJECT)
-        return WorkerNodeDaoTest.DEFAULT_OBJECT.worker_id
+        self.dao.insert(WorkerNodeDaoTest.DEFAULT_OBJECT)
+        return WorkerNodeDaoTest.DEFAULT_OBJECT.id
 
     def test_find_by_hostname(self):
         self._insert_obj()
@@ -238,11 +238,11 @@ class WorkerNodeDaoTest(BaseTest):
         no_obj_list = self.dao.find_by_liveness(alive=False)
         self.assertEqual(len(obj_list), 1)
         self.assertEqual(len(no_obj_list), 0)
-        self.assertEqual(obj_list[0].worker_id, worker_id)
+        self.assertEqual(obj_list[0].id, worker_id)
 
     def test_update(self):
         worker_id = self._insert_obj()
-        obj = self.dao.find_by_worker_id(worker_id)
+        obj = self.dao.find_by_id(worker_id)
         obj.is_alive = False
         update_result = self.dao.update(obj)
 

--- a/tests/unit/test_daos.py
+++ b/tests/unit/test_daos.py
@@ -217,31 +217,14 @@ class GradingRunDaoTest(BaseTest):
 
 class WorkerNodeDaoTest(BaseTest):
 
-    DEFAULT_OBJECT = models.WorkerNode(hostname="example.com")
+    DEFAULT_OBJECT = models.WorkerNode(worker_id="holygoply", hostname="example.com")
 
     def setUp(self):
         super().setUp()
         self.dao = daos.WorkerNodeDao(self.app.settings)
 
     def _insert_obj(self):
-        return self.dao.insert(WorkerNodeDaoTest.DEFAULT_OBJECT)
-
-    def test_insert(self):
-        result = self._insert_obj()
-        self.assertIsNotNone(result.inserted_id)
-
-    def test_find_by_id(self):
-        result = self._insert_obj()
-        obj = self.dao.find_by_id(result.inserted_id)
-
-        self.assertIsNotNone(obj)
-        for var in vars(obj):
-            if var == "id":
-                self.assertIsNotNone(obj.id)
-            else:
-                self.assertEqual(
-                    getattr(obj, var), getattr(WorkerNodeDaoTest.DEFAULT_OBJECT, var)
-                )
+        return self.dao.update(WorkerNodeDaoTest.DEFAULT_OBJECT)
 
     def test_find_by_hostname(self):
         self._insert_obj()

--- a/tests/unit/test_daos.py
+++ b/tests/unit/test_daos.py
@@ -227,6 +227,10 @@ class WorkerNodeDaoTest(BaseTest):
         self.dao.insert(WorkerNodeDaoTest.DEFAULT_OBJECT)
         return WorkerNodeDaoTest.DEFAULT_OBJECT.id
 
+    def test_insert(self):
+        worker_id = self._insert_obj()
+        self.assertIsNotNone(worker_id)
+
     def test_find_by_hostname(self):
         self._insert_obj()
         obj = self.dao.find_by_hostname(WorkerNodeDaoTest.DEFAULT_OBJECT.hostname)


### PR DESCRIPTION
Resolves https://github.com/illinois-cs241/broadway-api/issues/61
Worker side PR https://github.com/illinois-cs241/broadway-grader/pull/25

The db model is slightly different from the one in the issue description.
I kept the `_id` field but used mongo's upsert to update/insert new/existing workers.
So it's probably incompatible to the old model and we may need to drop the original `worker_node` collection before deploying(which should be fine?).

On the worker side, I also enforced the use of `"heartbeat"` field responded by api to make sure workers and api agree on the same heartbeat interval.

Another minor change: in api's router, `id_regex` allows digits in this branch. Not sure if there is any problem with that.